### PR TITLE
fix: remove nullish coalescing operator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,9 +160,8 @@ export async function bundleRequire(options: Options) {
   if (!JS_EXT_RE.test(options.filepath)) {
     throw new Error(`${options.filepath} is not a valid JS file`)
   }
-
-  const preserveTemporaryFile =
-    options.preserveTemporaryFile ?? !!process.env.BUNDLE_REQUIRE_PRESERVE
+  const temp = options.preserveTemporaryFile
+  const preserveTemporaryFile = temp !== null && temp !== void 0 ? temp : !!process.env.BUNDLE_REQUIRE_PRESERVE
   const cwd = options.cwd || process.cwd()
   const format = guessFormat(options.filepath)
   const tsconfig = loadTsConfig(options.cwd, options.tsconfig)


### PR DESCRIPTION
when I use tsup in production environment , Since TSUP relies on Bundle-Require, try compatible , Can you consider adaptation node12 , Since Nullism_coalescing_operator does not support, try to move