### PR TITLE
feat: adds support for workspace protocol

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,13 +3,14 @@ import path from "path"
 import { createRequire } from "module"
 import { RequireFunction } from "."
 
-const getPkgType = (): string | undefined => {
+const getPkg = (): Record<string, any> | undefined => {
   try {
-    const pkg = JSON.parse(
-      fs.readFileSync(path.resolve("package.json"), "utf-8"),
-    )
-    return pkg.type
+    return JSON.parse(fs.readFileSync(path.resolve("package.json"), "utf-8"))
   } catch (error) {}
+}
+
+const getPkgType = (): string | undefined => {
+  return getPkg()?.type
 }
 
 export function guessFormat(inputFile: string): "esm" | "cjs" {
@@ -25,6 +26,16 @@ export function guessFormat(inputFile: string): "esm" | "cjs" {
     return "esm"
   }
   return "cjs"
+}
+
+export const getPkgDependencies = (): Record<string, string> => {
+  const pkg = getPkg()
+  return {
+    ...pkg?.dependencies,
+    ...pkg?.devDependencies,
+    ...pkg?.peerDependencies,
+    ...pkg?.optionalDependencies,
+  }
 }
 
 // Injected by TSUP


### PR DESCRIPTION
Currently, dependencies that live in another package within a monorepo workspace get treated as external, which causes a error. 

This change adds support for monorepos using the  `workspace:` protocol by treating workspace packages as notExternal.

This is done by checking the package.json for dependencies that are referenced using `workspace:` protocol
e.g. `"foo": "workspace:*"`,
and adding them to the `notExternal` array that is passed to the `externalPlugin`.

- resolves #40 

Info about workspaces
- [https://pnpm.io/workspaces](https://pnpm.io/workspaces)
- [https://yarnpkg.com/features/workspaces](https://yarnpkg.com/features/workspaces)